### PR TITLE
Generated password text area resizes based on number of passwords

### DIFF
--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -17,6 +17,10 @@ body {
   max-height: 4rem;
 }
 
+textarea {
+  resize: none;
+}
+
 .bd-clipboard,.bd-edit {
   position: relative;
   display: none;

--- a/src/index.html
+++ b/src/index.html
@@ -106,7 +106,7 @@
               </div>
               <div class="card-body">
                 <textarea type="text" readonly
-                class="form-control form-control-plaintext border-0 font-monospace mb-3"
+                class="form-control form-control-plaintext border-0 font-monospace mb-3" rows="3"
                   id="generated_password"></textarea>
 
                   <div id="passwordErrorContainer"></div>

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -84,6 +84,8 @@ const XKP = {
 
     try {
       const num = parseInt(XKP.config.numberOfPasswords.val());
+      // Set passwordArea height to accomodate number of passwords
+      generated_password.rows = num;
 
       const passAndStats = XKP.config.xkpasswd.generatePassword(num);
 


### PR DESCRIPTION
In index.html, I set a default number of rows to the generated_passwords text area first, setting it to 3 since that's the default number of passwords. If the user pushes generate, they're not shown a text area that's too small.

In index.mjs I added to the generatePasswords function. I used the constant num (which is the number of passwords) to set the number of rows for the generated_passwords text area. Result is that changing the number of passwords now changes the height of the text area to accommodate them.

Now that the text area resizes automatically, I removed the resize handle by setting textarea resize to non in site.css. I would have preferred to set the text area with id="generated_password" to resize: none, but I didn't immediately see how to do that.

All tests passed, and coverage stayed consistent (it wasn't 80% when I started.)

This fixes issue #19.