### PR TITLE
fix: #25 prevent FOUC when page loads

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -12,7 +12,9 @@
 </head>
 
 <body>
-  <div class="container mt-3">
+  <!-- Main page -->
+  <!-- Hidden by default to prevent a flash of unstyled content (FOUC) when the page loads. -->
+  <div class="container mt-3" fouc="true" style="visibility: hidden;">
     <div class="row"> <!-- open row for all content above footer -->
       <section id="main" class="col order-2"> <!-- open section for content right of graphic -->
 
@@ -354,8 +356,9 @@
     </footer>
   </div>
 
-  <!-- Modal about -->
-  <div class="modal fade" id="about" tabindex="-1" aria-labelledby="aboutLabel" aria-hidden="true">
+  <!-- Modal about-->
+  <!-- Hidden by default to prevent a flash of unstyled content (FOUC) when the page loads. -->
+  <div class="modal fade" id="about" fouc="true" tabindex="-1" aria-labelledby="aboutLabel" aria-hidden="true" style="visibility: hidden;">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">
@@ -390,7 +393,8 @@
   </div>
 
   <!-- Modal donate -->
-  <div class="modal fade" id="donate" tabindex="-1" aria-labelledby="donateLabel" aria-hidden="true">
+  <!-- Hidden by default to prevent a flash of unstyled content (FOUC) when the page loads. -->
+  <div class="modal fade" id="donate" fouc="true" tabindex="-1" aria-labelledby="donateLabel" aria-hidden="true" style="visibility: hidden;">
     <div class="modal-dialog">
       <div class="modal-content">
         <div class="modal-header">

--- a/src/index.mjs
+++ b/src/index.mjs
@@ -78,5 +78,15 @@ $(() => {
     (tooltipTriggerEl) => new Tooltip(tooltipTriggerEl));
 
   XKP.init();
-});
 
+  // Now that the DOM is ready, find all of the 'div' elements that
+  // were identified to have the potential to flash unstyled content
+  // as the page loads and make them visible.
+  const foucElements = document.querySelectorAll('div[fouc=\'true\']');
+  for (const fouc of foucElements) {
+    if (fouc.style !== null) {
+      // Make the element visible.
+      fouc.style.visibility = 'visible';
+    }
+  }
+});


### PR DESCRIPTION
Prevents a flash of unstyled content when the page loads by setting all affected root 'div' elements to be invisible in the HTML source. Then once the DOM is ready, make these elements visible.