### PR TITLE
Bold fonts were ugly - made them more elegant

### DIFF
--- a/src/assets/site.css
+++ b/src/assets/site.css
@@ -7,7 +7,6 @@ body {
   --bs-body-font-family: var(--bs-font-sans-serif);
   --bs-font-family: var(--bs-font-sans-serif);
   font-family: 'Noto Sans', sans-serif;
-  font-weight: bold;
 }
 
 #main {
@@ -84,5 +83,5 @@ body {
 .link { color: #0602e8; }
 
 .input-group-text {
-  font-weight: 800;
+  font-weight: 400;
 }

--- a/src/index.html
+++ b/src/index.html
@@ -128,7 +128,7 @@
                                 <select name="dict" id="dict" class="form-select">
                                   <option value="english" selected="selected">English</option>
                                 </select>
-                                <label for="num_words" class="input-group-text">No of Words</label>
+                                <label for="num_words" class="input-group-text"># of Words</label>
                                 <input type="number" min="1" max="10" step="1" value="1" class="form-control"
                                   name="num_words" id="num_words" />
                               </div>

--- a/src/index.html
+++ b/src/index.html
@@ -328,7 +328,7 @@
                 <span class="fw-bolder">Strength </span><span class="btn btn-stats btn-success"
                   id="password_strength">test</span>
               </p>
-              <p class="fw-lighter">
+              <p class="fw-light">
                 <span class="fw-bolder">Entropy</span><span id="entropy_blind">
                 </span> blind & <span class="btn btn-stats btn-warning" id="entropy_seen">seen</span>&nbsp;with
                 full knowledge


### PR DESCRIPTION
I originally made them bolder and heavier weight because the text area about entropy was super thin and hard to read. But my solution was a sledge hammer. It now has easier to read text but not so shouty.

Also changed "No of passwords" to "# of passwords" because screen readers read "No" as "No", not "number".