### PR TITLE
Fix typo in banner alt texts.

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -25,7 +25,7 @@
               <!-- show this up to lg -->
               <source media="(max-width: 768px)" srcset="assets/topBanner.png">
               <!-- else show this -->
-              <img class="img-fluid" aria-hidden="true" alt="XKPasswd - A Secure Memorable Password Generators"
+              <img class="img-fluid" aria-hidden="true" alt="XKPasswd - A Secure Memorable Password Generator"
                 src="assets/topBanner.png">
             </picture>
           </section>
@@ -359,7 +359,7 @@
           <!-- show this on large and above -->
           <source media="(max-width: 992px)" srcset="assets/sideBanner.png">
           <!-- else show this -->
-          <img class="img-fluid" aria-hidden="true" alt="XKPasswd - A Secure Memorable Password Generators"
+          <img class="img-fluid" aria-hidden="true" alt="XKPasswd - A Secure Memorable Password Generator"
             src="assets/sideBanner.png">
         </picture>
       </section> <!-- close section for graphic -->


### PR DESCRIPTION
The alt text for the banner images both say, "A Secure Memorable Password Generators." The "Generators" should be singular, so I removed the ending "s."