### PR TITLE
FEAT: moved copy config url button

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -320,21 +320,23 @@
 
                     <!-- settings-link -->
                     <div id="settings-link" class="row g-1 mt-1 mb-3">
-                      <div class="mt-2 col-md-8 col-md-8">
+                      <div class="mt-2 col-md-8">                        
                         <div class="input-group">
-                          <label for="savedSettingsLink" class="input-group-text">Settings link</label>
+                          <label for="savedSettingsLink" class="input-group-text">
+                            <button id="copySettingsLink"
+                            class="list-group-item px-0"
+                            aria-label="Copy link"><i class="me-3 bi bi-copy"></i>
+                            </button>
+                            Copy Config URL
+                          </label>
                           <input class="form-control rounded-end" type="text" placeholder="" readonly disabled="disabled"
                             name="savedSettingsLink" id="savedSettingsLink" minlength="2" maxlength="20" size="1" />
                         </div>
-                       </div>
-                       <div class="mt-2 col-sm-8 col-md-4">
-                        <div class="input-group">
-                          <button id="copySettingsLink"
-                          class="list-group-item px-0"
-                          aria-label="Copy link"><i class="me-3 bi bi-copy"></i>Copy
-                        </button>
+                        <div id="bookmarkConfigUrl" class="form-text">Bookmark Config URL to recreate the current settings config
                         </div>
-                      </div>
+
+                       </div>
+                  
                     </div> <!-- /settings-link -->
 
                   </div> <!-- /accordion configOptions -->


### PR DESCRIPTION
added text to explain what it is, reworded field to be config not settings

This should be in a branch called fix-settings-link when it gets pulled but I don't know how to tell the bartificer version to do that.